### PR TITLE
Fix type exports

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,2 @@
 // @deno-types="./node_modules/immutable/dist/immutable-nonambient.d.ts"
 export * from "./node_modules/immutable/dist/immutable.es.js";
-export * from './node_modules/immutable/dist/immutable-nonambient.d.ts';


### PR DESCRIPTION
In Deno, there is no need to export the JS file and the d.ts file at the same time. This change will prevent warnings from being printed.

<img width="516" src="https://user-images.githubusercontent.com/2622837/134673111-d1e59c6b-701b-4e97-82c3-bf22464d90d3.png">
